### PR TITLE
fix: #14 チャット画面のいずれかをクリックすることで右クリックメニューを非表示可能に

### DIFF
--- a/src/components/chat-area.jsx
+++ b/src/components/chat-area.jsx
@@ -4,7 +4,7 @@ import React, { useState } from 'react'
 export const ChatArea = () => {
 	const [text, setText] = useState('')
 	const [messages, setMessage] = useState([])
-	const { isOpen, onToggle } = useDisclosure()
+	const { isOpen, onOpen, onClose } = useDisclosure()
 	const [menuIndex, setMenuIndex] = useState(null) // 右クリックされたときのメニューのindexを保持する
 
 	const sendMessage = (e) => {
@@ -21,11 +21,11 @@ export const ChatArea = () => {
 	const handleRightClick = (e, index) => {
 		e.preventDefault()
 		setMenuIndex(index) // 右クリックされたときのメニューのindexを保持する
-		onToggle()
+		onOpen() // 右クリック時にメニューを開く
 	}
 
 	return (
-		<Box>
+		<Box onClick={() => onClose()}> {/* クリックしたときにメニューを閉じる */}
 			<Flex direction='column' align='flex-end' rowGap={5} h="80vh" px={10} py={8} bg={'blue.200'} overflowY='auto'>
 				{messages.map((message, index) => (
 					<Box pos='relative' key={index} onContextMenu={(e) => handleRightClick(e, index)}>


### PR DESCRIPTION
<!-- #[Issue num] [prefex]: title -->
<!-- #1 feat: first commit -->
# 目的

- このプルリクエストが解決する課題や目標を記述
- #14 
- 右クリック時に表示されるメニューを非表示しやすくする

## 背景

- このプルリクエストが必要となった経緯や背景を記述
- 右クリック時に表示されるメニューは再びメッセージを右クリックしないと非表示にできず、操作性を損なっていた

## 変更内容

- このプルリクエストで行った変更内容や影響範囲を記述
- 右クリック時に`onToggle`でメニューの表示を制御していたのを、右クリック時には`onOpen`、画面内のいずれかをクリックで`onClose`で制御することにより画面のいずれかをクリックすることでメニューを非表示できる

## テスト方法

- このプルリクエストで行ったテスト方法や結果を記述
- アプリ内での動作確認のみ

## レビューに必要な情報

- レビュアーに伝えたい情報や注意点を記述
- 特になし