### PR TITLE
feat: 日本語と英語の音声入力対応 ボタンをアイコンに変更

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "openai": "^3.3.0",
         "react": "18.2.0",
         "react-dom": "18.2.0",
+        "react-icons": "^4.10.1",
         "react-speech-recognition": "^3.10.0",
         "regenerator-runtime": "^0.14.0"
       }
@@ -5940,6 +5941,14 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.10.1.tgz",
+      "integrity": "sha512-/ngzDP/77tlCfqthiiGNZeYFACw85fUjZtLbedmJ5DTlNDIwETxhwBzdOJ21zj4iJdvc0J3y7yOsX3PpxAJzrw==",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,9 @@
         "next-pwa": "^5.6.0",
         "openai": "^3.3.0",
         "react": "18.2.0",
-        "react-dom": "18.2.0"
+        "react-dom": "18.2.0",
+        "react-speech-recognition": "^3.10.0",
+        "regenerator-runtime": "^0.14.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -5988,6 +5990,14 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-speech-recognition": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/react-speech-recognition/-/react-speech-recognition-3.10.0.tgz",
+      "integrity": "sha512-EVSr4Ik8l9urwdPiK2r0+ADrLyDDrjB0qBRdUWO+w2MfwEBrj6NuRmy1GD3x7BU/V6/hab0pl8Lupen0zwlJyw==",
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/react-style-singleton": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "next-pwa": "^5.6.0",
     "openai": "^3.3.0",
     "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "react-dom": "18.2.0",
+    "react-speech-recognition": "^3.10.0",
+    "regenerator-runtime": "^0.14.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "openai": "^3.3.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "react-icons": "^4.10.1",
     "react-speech-recognition": "^3.10.0",
     "regenerator-runtime": "^0.14.0"
   }

--- a/src/components/app-header.jsx
+++ b/src/components/app-header.jsx
@@ -1,24 +1,22 @@
 import { ChevronLeftIcon, HamburgerIcon } from '@chakra-ui/icons'
-import { Flex, Text } from '@chakra-ui/react'
+import { Flex, Select, Text } from '@chakra-ui/react'
 import Link from 'next/link'
 import React from 'react'
 
-export const AppHeader = () => {
+export const AppHeader = ({ speechLanguage, setSpeechLanguage }) => {
 	return (
-			<Flex h='32px' mx={5} my={3} align='center' justify='space-between'>
-				<Link href='/'>
-					<ChevronLeftIcon boxSize={8} />
-				</Link>	
-				<Text fontSize={18}>Chat Title</Text>
-				<AppMenu />
+		<Flex h='32px' mx={5} my={3} align='center' justify='space-between'>
+			<Link href='/'>
+				<ChevronLeftIcon boxSize={8} />
+			</Link>
+			<Text fontSize={18}>Chat Title</Text>
+			<Flex align='center' columnGap={2}>
+				<Select value={speechLanguage} placeholder='Language' variant='filled' size='sm' onChange={(e) => setSpeechLanguage(e.target.value)}>
+					<option value='en-US'>en-US</option>
+					<option value='ja'>ja</option>
+				</Select>
+				<HamburgerIcon boxSize={6} />
 			</Flex>
-	)
-}
-
-export const AppMenu = () => {
-	return (
-		<div>
-			<HamburgerIcon boxSize={6} />
-		</div>
+		</Flex>
 	)
 }

--- a/src/components/chat-area.jsx
+++ b/src/components/chat-area.jsx
@@ -1,5 +1,6 @@
 import { Box, Button, Fade, Flex, Image, Input, Text, useDisclosure } from '@chakra-ui/react'
 import React, { use, useEffect, useState } from 'react'
+import SpeechRecognition, { useSpeechRecognition } from 'react-speech-recognition';
 
 export const ChatArea = () => {
 	const [message, setMessage] = useState({ role: "user", content: "" });
@@ -11,6 +12,7 @@ export const ChatArea = () => {
 	const { isOpen, onOpen, onClose } = useDisclosure();
 	const [menuIndex, setMenuIndex] = useState(null); // 右クリックされたときのメニューのindexを保持する
 	const [viewportHeight, setViewportHeight] = useState(100);
+	const [isClient, setIsClient] = useState(false);
 
 	const handleInputChange = (value) => {
 		setMessage({ role: "user", content: value });
@@ -73,6 +75,23 @@ export const ChatArea = () => {
 		};
 	}, []);
 
+	const { transcript, listening, resetTranscript, browserSupportsSpeechRecognition } = useSpeechRecognition();
+	
+	useEffect(() => {
+		setIsClient(true);
+	}, []);
+	if (isClient && !browserSupportsSpeechRecognition) return <Box>ブラウザが音声認識に対応していません。</Box>;
+
+	useEffect(() => {
+		transcript && setMessage({ role: "user", content: transcript });
+		console.log(transcript)
+	}, [transcript])
+
+	const resetVoiceMessage = () => {
+		resetTranscript()
+		setMessage({ role: "user", content: "" });
+	}
+
 	console.log(chats)
 
 	return (
@@ -113,7 +132,9 @@ export const ChatArea = () => {
 			<form onSubmit={(e) => sendMessage(e)} >
 				<Flex w='100%' maxW={800} h='60px' px={5} mx='auto' mt={5}>
 					<Input mr={4} variant='filled' placeholder="Let's Chat!!" type="text" value={message.content} onChange={(e) => handleInputChange(e.target.value)} />
-					<Button colorScheme='teal' type='submit'>send</Button>
+					<Button mr={2} colorScheme='teal' type='submit'>send</Button>
+					<Button mr={2} colorScheme='green' variant={listening ? 'solid': 'ghost'} onClick={() => SpeechRecognition.startListening({language: 'ja'})}>speak</Button>
+					<Button mr={2} colorScheme='red' variant='ghost' onClick={() => resetVoiceMessage()}>Reset</Button>
 				</Flex>
 			</form>
 		</Box>

--- a/src/components/chat-area.jsx
+++ b/src/components/chat-area.jsx
@@ -3,7 +3,7 @@ import { PiMicrophoneFill, PiPaperPlaneRightFill } from 'react-icons/pi'
 import React, { use, useEffect, useState } from 'react'
 import SpeechRecognition, { useSpeechRecognition } from 'react-speech-recognition';
 
-export const ChatArea = () => {
+export const ChatArea = ({ speechLanguage }) => {
 	const [message, setMessage] = useState({ role: "user", content: "" });
 	const [chats, setChats] = useState([{
 		role: "system",
@@ -78,7 +78,7 @@ export const ChatArea = () => {
 	}, []);
 
 	const { transcript, listening, resetTranscript, browserSupportsSpeechRecognition } = useSpeechRecognition();
-	
+
 	useEffect(() => {
 		setIsClient(true);
 	}, []);
@@ -130,7 +130,9 @@ export const ChatArea = () => {
 				<Flex w='100%' maxW={800} h='60px' px={5} mx='auto' mt={5}>
 					<Input mr={4} variant='filled' placeholder="Let's Chat!!" type="text" value={message.content} onChange={(e) => handleInputChange(e.target.value)} />
 					<Button mr={2} colorScheme='teal' type='submit'><Icon as={PiPaperPlaneRightFill} /></Button>
-					<Button mr={2} colorScheme='green' variant={listening ? 'solid': 'ghost'} onClick={() => SpeechRecognition.startListening({language: 'ja'})}><Icon as={PiMicrophoneFill} /></Button>
+					{speechLanguage !== "" && (
+						<Button mr={2} colorScheme='green' variant={listening ? 'solid' : 'ghost'} onClick={() => SpeechRecognition.startListening({ language: speechLanguage })}><Icon as={PiMicrophoneFill} /></Button>
+					)}
 				</Flex>
 			</form>
 		</Box>

--- a/src/components/chat-area.jsx
+++ b/src/components/chat-area.jsx
@@ -1,5 +1,5 @@
 import { Box, Button, Fade, Flex, Icon, Image, Input, Text, useDisclosure } from '@chakra-ui/react'
-import { PiMicrophoneFill, PiMicrophoneSlashFill } from 'react-icons/pi'
+import { PiMicrophoneFill, PiPaperPlaneRightFill } from 'react-icons/pi'
 import React, { use, useEffect, useState } from 'react'
 import SpeechRecognition, { useSpeechRecognition } from 'react-speech-recognition';
 
@@ -23,6 +23,7 @@ export const ChatArea = () => {
 		try {
 			e.preventDefault()
 			if (message.content === "") return;
+			resetTranscript()
 
 			setMessage({ role: "user", content: "" });
 			setChats((prev) => [...prev, message]);
@@ -88,11 +89,6 @@ export const ChatArea = () => {
 		console.log(transcript)
 	}, [transcript])
 
-	const resetVoiceMessage = () => {
-		resetTranscript()
-		setMessage({ role: "user", content: "" });
-	}
-
 	console.log(chats)
 
 	return (
@@ -133,9 +129,8 @@ export const ChatArea = () => {
 			<form onSubmit={(e) => sendMessage(e)} >
 				<Flex w='100%' maxW={800} h='60px' px={5} mx='auto' mt={5}>
 					<Input mr={4} variant='filled' placeholder="Let's Chat!!" type="text" value={message.content} onChange={(e) => handleInputChange(e.target.value)} />
-					<Button mr={2} colorScheme='teal' type='submit'>send</Button>
+					<Button mr={2} colorScheme='teal' type='submit'><Icon as={PiPaperPlaneRightFill} /></Button>
 					<Button mr={2} colorScheme='green' variant={listening ? 'solid': 'ghost'} onClick={() => SpeechRecognition.startListening({language: 'ja'})}><Icon as={PiMicrophoneFill} /></Button>
-					<Button mr={2} colorScheme='red' variant='ghost' onClick={() => resetVoiceMessage()}><Icon as={PiMicrophoneSlashFill} /></Button>
 				</Flex>
 			</form>
 		</Box>

--- a/src/components/chat-area.jsx
+++ b/src/components/chat-area.jsx
@@ -1,4 +1,5 @@
-import { Box, Button, Fade, Flex, Image, Input, Text, useDisclosure } from '@chakra-ui/react'
+import { Box, Button, Fade, Flex, Icon, Image, Input, Text, useDisclosure } from '@chakra-ui/react'
+import { PiMicrophoneFill, PiMicrophoneSlashFill } from 'react-icons/pi'
 import React, { use, useEffect, useState } from 'react'
 import SpeechRecognition, { useSpeechRecognition } from 'react-speech-recognition';
 
@@ -133,8 +134,8 @@ export const ChatArea = () => {
 				<Flex w='100%' maxW={800} h='60px' px={5} mx='auto' mt={5}>
 					<Input mr={4} variant='filled' placeholder="Let's Chat!!" type="text" value={message.content} onChange={(e) => handleInputChange(e.target.value)} />
 					<Button mr={2} colorScheme='teal' type='submit'>send</Button>
-					<Button mr={2} colorScheme='green' variant={listening ? 'solid': 'ghost'} onClick={() => SpeechRecognition.startListening({language: 'ja'})}>speak</Button>
-					<Button mr={2} colorScheme='red' variant='ghost' onClick={() => resetVoiceMessage()}>Reset</Button>
+					<Button mr={2} colorScheme='green' variant={listening ? 'solid': 'ghost'} onClick={() => SpeechRecognition.startListening({language: 'ja'})}><Icon as={PiMicrophoneFill} /></Button>
+					<Button mr={2} colorScheme='red' variant='ghost' onClick={() => resetVoiceMessage()}><Icon as={PiMicrophoneSlashFill} /></Button>
 				</Flex>
 			</form>
 		</Box>

--- a/src/pages/_app.jsx
+++ b/src/pages/_app.jsx
@@ -1,4 +1,5 @@
 import '@/styles/globals.css'
+import 'regenerator-runtime'
 import { ChakraProvider } from '@chakra-ui/react'
 
 export default function App({ Component, pageProps }) {

--- a/src/pages/chat/index.jsx
+++ b/src/pages/chat/index.jsx
@@ -5,7 +5,7 @@ import React from 'react'
 
 export default function chat() {
 	return (
-		<div overflowY='hidden'>
+		<div>
 			<AppHeader />
 			<ChatArea />
 		</div>

--- a/src/pages/chat/index.jsx
+++ b/src/pages/chat/index.jsx
@@ -1,13 +1,14 @@
 import { AppHeader } from '@/components/app-header'
 import { ChatArea } from '@/components/chat-area'
 import Link from 'next/link'
-import React from 'react'
+import React, { useState } from 'react'
 
 export default function chat() {
+	const [speechLanguage, setSpeechLanguage] = useState('en-US')
 	return (
 		<div>
-			<AppHeader />
-			<ChatArea />
+			<AppHeader speechLanguage={speechLanguage} setSpeechLanguage={setSpeechLanguage} />
+			<ChatArea speechLanguage={speechLanguage} />
 		</div>
 	)
 }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -30,11 +30,11 @@ export default function Home() {
                 <Text fontSize='md'>たとえぼっちでも大丈夫！</Text>
               </Box>
               <ButtonGroup spacing='30px'>
-                <Link href='/login' passHref>
-                  <Button as='a' colorScheme='green' size='lg'>ログインしてみる</Button>
+                <Link href='/login'>
+                  <Button colorScheme='green' size='lg'>ログインしてみる</Button>
                 </Link>
-                <Link href='/chat' passHref>
-                  <Button as='a' colorScheme='pink' color='white' size='lg'>チャットを始めてみる</Button>
+                <Link href='/chat'>
+                  <Button colorScheme='pink' color='white' size='lg'>チャットを始めてみる</Button>
                 </Link>
               </ButtonGroup>
             </Flex>


### PR DESCRIPTION
<!-- #[Issue num] [prefex]: title -->
<!-- #1 feat: first commit -->
# 目的

- このプルリクエストが解決する課題や目標を記述
- #37 
- #38 
- 多言語の音声入力に対応する（まずは日本語と英語）

## 背景

- このプルリクエストが必要となった経緯や背景を記述
- テキスト入力より音声入力のほうが、英会話に向いているため
- 多言語対応するにもニッチな言語は緊急に要しないため、最低限欲しい日本語と英語に対応するため

## 変更内容

- このプルリクエストで行った変更内容や影響範囲を記述
- アプリのヘッダーにて無駄なコンポーネントの削除
- 音声入力の実装
- 音声入力ボタンのスタイル追加
  - 常時はアイコンが緑色だが、音声認識中はアイコンが白色になり、背景が緑色で埋まったボタンになる
- アプリヘッダー右側のセレクトUIによって、音声入力言語を英語: 'en-US'と日本語: 'ja'のそれぞれのオプションから選択できるように
  - **言語の初期値は英語: 'en-US'である**
  - 言語を選択していない状態（セレクトのLanguageオプション）では、音声入力ボタンUIを消す仕様にした
  - つまり**音声入力言語を指定しないとき音声入力できなくなる**（あくまでアプリ内のUIから デバイスの音声入力からは可能）

## テスト方法

- このプルリクエストで行ったテスト方法や結果を記述
- その時その時のデバッグのみ
- バグはその場で修正済み

## レビューに必要な情報

- レビュアーに伝えたい情報や注意点を記述
- 仕様勝手に決めちゃったので何かあれば意見ください