### PR TITLE
チャットタイトルの編集とチャットの削除機能を追加 - Feature/#55 editable chat title

### DIFF
--- a/src/components/editable-controls.jsx
+++ b/src/components/editable-controls.jsx
@@ -1,0 +1,19 @@
+import { useFirestore } from '@/hooks/useFirestore';
+import { ButtonGroup, Flex, IconButton, useEditableContext } from '@chakra-ui/react'
+import { PiCheck, PiPencilSimpleLine, PiTrash, PiTrashSimple, PiX } from 'react-icons/pi';
+
+export const EditableControls = ({ userId, chatsId, chatTitle }) => {
+	const { isEditing, getEditButtonProps, getCancelButtonProps, getSubmitButtonProps, on } = useEditableContext()
+	const { addChatTitle } = useFirestore()
+	return isEditing ? (
+		<ButtonGroup alignItems='center' justifyContent='center' size='xs' ml='1rem'>
+			<IconButton as={PiCheck} variant='ghost' {...getSubmitButtonProps()} onSubmit={addChatTitle(userId, chatsId, chatTitle)} />
+			<IconButton as={PiX} variant='ghost' {...getCancelButtonProps()} />
+		</ButtonGroup>
+	) : (
+		<ButtonGroup alignItems='center' justifyContent='center' size='xs'>
+			<IconButton as={PiPencilSimpleLine} variant='ghost' {...getEditButtonProps()} />
+			<IconButton as={PiTrashSimple} variant='ghost' {...getCancelButtonProps()} />
+		</ButtonGroup>
+	)
+}

--- a/src/components/editable-controls.jsx
+++ b/src/components/editable-controls.jsx
@@ -1,19 +1,52 @@
 import { useFirestore } from '@/hooks/useFirestore';
-import { ButtonGroup, Flex, IconButton, useEditableContext } from '@chakra-ui/react'
-import { PiCheck, PiPencilSimpleLine, PiTrash, PiTrashSimple, PiX } from 'react-icons/pi';
+import { AlertDialog, AlertDialogBody, AlertDialogContent, AlertDialogFooter, AlertDialogHeader, AlertDialogOverlay, Button, ButtonGroup, Flex, IconButton, useDisclosure, useEditableContext } from '@chakra-ui/react'
+import { useRef } from 'react';
+import { PiCheck, PiPencilSimpleLine, PiTrash, PiX } from 'react-icons/pi';
 
-export const EditableControls = ({ userId, chatsId, chatTitle }) => {
-	const { isEditing, getEditButtonProps, getCancelButtonProps, getSubmitButtonProps, on } = useEditableContext()
+export const EditableControls = ({ chatsData, setChatsData, userId, chatsId, chatTitle }) => {
+	const { isEditing, getEditButtonProps, getCancelButtonProps, getSubmitButtonProps } = useEditableContext()
 	const { addChatTitle } = useFirestore()
+	const { isOpen, onOpen, onClose } = useDisclosure()
+	const cancelRef = useRef()
+
+	const handleDelete = () => {
+		const { deleteChatsData } = useFirestore()
+		
+		setChatsData(chatsData.filter((chat) => chat.id !== chatsId))
+		deleteChatsData(userId, chatsId)
+		onClose()
+	}
+
 	return isEditing ? (
 		<ButtonGroup alignItems='center' justifyContent='center' size='xs' ml='1rem'>
 			<IconButton as={PiCheck} variant='ghost' {...getSubmitButtonProps()} onSubmit={addChatTitle(userId, chatsId, chatTitle)} />
 			<IconButton as={PiX} variant='ghost' {...getCancelButtonProps()} />
 		</ButtonGroup>
 	) : (
-		<ButtonGroup alignItems='center' justifyContent='center' size='xs'>
-			<IconButton as={PiPencilSimpleLine} variant='ghost' {...getEditButtonProps()} />
-			<IconButton as={PiTrashSimple} variant='ghost' {...getCancelButtonProps()} />
-		</ButtonGroup>
+		<>
+			<ButtonGroup alignItems='center' justifyContent='center' size='xs'>
+				<IconButton as={PiPencilSimpleLine} variant='ghost' {...getEditButtonProps()} />
+				<IconButton as={PiTrash} variant='ghost' {...getCancelButtonProps()} onClick={onOpen} />
+			</ButtonGroup>
+			<AlertDialog
+				motionPreset='slideInBottom'
+				leastDestructiveRef={cancelRef}
+				onClose={onClose}
+				isOpen={isOpen}
+				isCentered
+			>
+				<AlertDialogOverlay />
+
+				<AlertDialogContent>
+					<AlertDialogHeader>⚠️警告</AlertDialogHeader>
+
+					<AlertDialogBody>チャットデータを削除しても構いませんか？ チャットデータは完全に削除され、2度と復元できません!!</AlertDialogBody>
+					<AlertDialogFooter>
+						<Button ref={cancelRef} onClick={onClose}>閉じる</Button>
+						<Button colorScheme='red' ml='20px' onClick={() => handleDelete()}>削除する</Button>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
+		</>
 	)
 }

--- a/src/hooks/useFirestore.js
+++ b/src/hooks/useFirestore.js
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react"
 import { db } from "../lib/firebase"
-import { collection, addDoc, getDocs, Timestamp, setDoc, doc } from "firebase/firestore"
+import { collection, addDoc, getDocs, Timestamp, setDoc, doc, updateDoc } from "firebase/firestore"
 
 export const useFirestore = () => {
     // const addFirestoreChat = async (newChat)
@@ -10,6 +10,13 @@ export const useFirestore = () => {
         await setDoc(cRef, {
             id: chatsId,
             updatedAt: Timestamp.now(),
+        })
+    }
+
+    const addChatTitle = async (userId, chatsId, chatTitle) => {
+        const cRef = doc(db, 'users', userId, 'chats', chatsId)
+        await updateDoc(cRef, {
+            title: chatTitle,
         })
     }
 
@@ -69,5 +76,5 @@ export const useFirestore = () => {
         return chatsId
     }
 
-    return { addChatsData, addFirestoreDoc, useMessages, useChatsIds }
+    return { addChatsData, addChatTitle, addFirestoreDoc, useMessages, useChatsIds }
 }

--- a/src/hooks/useFirestore.js
+++ b/src/hooks/useFirestore.js
@@ -1,10 +1,8 @@
 import { useEffect, useState } from "react"
 import { db } from "../lib/firebase"
-import { collection, addDoc, getDocs, Timestamp, setDoc, doc, updateDoc } from "firebase/firestore"
+import { collection, addDoc, getDocs, Timestamp, setDoc, doc, updateDoc, deleteDoc } from "firebase/firestore"
 
 export const useFirestore = () => {
-    // const addFirestoreChat = async (newChat)
-
     const addChatsData = async (userId, chatsId) => {
         const cRef = doc(db, 'users', userId, 'chats', chatsId)
         await setDoc(cRef, {
@@ -12,6 +10,11 @@ export const useFirestore = () => {
             updatedAt: Timestamp.now(),
         })
     }
+
+    const deleteChatsData = async (userId, chatsId) => {
+        const cRef = doc(db, 'users', userId, 'chats', chatsId)
+        await deleteDoc(cRef)
+    } // Firestoreからチャットデータを削除する
 
     const addChatTitle = async (userId, chatsId, chatTitle) => {
         const cRef = doc(db, 'users', userId, 'chats', chatsId)
@@ -52,29 +55,5 @@ export const useFirestore = () => {
         return messages
     }
 
-    const getChatsId = async (userId) => {
-        const snapshot = await getDocs(collection(db, 'users', userId, 'chats'))
-        const getData = snapshot.docs.map((doc) => {
-            const data = doc.data()
-            data.id = doc.id
-            return data
-        })
-        return getData
-    }
-
-    const useChatsIds = (user, session) => {
-        const [chatsId, setChatsId] = useState([])
-        useEffect(() => {
-            if (user && session) {
-                ; (async () => {
-                    const data = await getChatsId(user.email)
-                    setChatsId(data.sort((a, b) => b.updatedAt.seconds - a.updatedAt.seconds))
-                })()
-            }
-        }, [user])
-
-        return chatsId
-    }
-
-    return { addChatsData, addChatTitle, addFirestoreDoc, useMessages, useChatsIds }
+    return { addChatsData, deleteChatsData, addChatTitle, addFirestoreDoc, useMessages }
 }

--- a/src/pages/dashboard/index.jsx
+++ b/src/pages/dashboard/index.jsx
@@ -1,12 +1,13 @@
 import { DashboardNav } from '@/components/dashboard-nav'
 import { useFirestore } from '@/hooks/useFirestore'
-import { Box, Flex, Heading, Icon, Skeleton, Text } from '@chakra-ui/react'
+import { Box, Editable, EditableInput, EditablePreview, Flex, Heading, Icon, Skeleton, Text } from '@chakra-ui/react'
 import Link from 'next/link'
 import { useSession } from 'next-auth/react'
 import { useEffect, useState } from 'react'
 import { useLoading } from '@/hooks/useLoading'
 import { PiLink, PiPlusCircleFill } from 'react-icons/pi'
 import Randomstring from 'randomstring'
+import { EditableControls } from '@/components/editable-controls'
 
 export default function Dashboard() {
 	const { useChatsIds } = useFirestore()
@@ -14,6 +15,7 @@ export default function Dashboard() {
 	const [isFetched, setIsFetched] = useState(false)
 	const { data: session } = useSession({ required: true })
 	const { isLoading, isPageLoading } = useLoading()
+	const [chatTitle, setChatTitle] = useState('')
 
 	useEffect(() => {
 		if (!isFetched && session) {
@@ -38,16 +40,26 @@ export default function Dashboard() {
 				<Flex direction='column' align='flex-start' rowGap='20px' py='20px'>
 					{(!currentUser || isLoading || isPageLoading || chatsIds.length === 0) &&
 						<>
-							<Skeleton h='65px' w='full' borderRadius='10px'></Skeleton>
-							<Skeleton h='65px' w='full' borderRadius='10px'></Skeleton>
+							<Skeleton h='52px' w='full' borderRadius='10px'></Skeleton>
+							<Skeleton h='52px' w='full' borderRadius='10px'></Skeleton>
 						</>
 					}
 					{currentUser && !isLoading && !isPageLoading && chatsIds.map((chatsId) => (
-						<Box w='full' px='30px' py='10px' bg='gray.200' borderRadius='10px'>
-							<Link key={chatsId} href={`/chat/${chatsId.id}`}>
-								<Text fontSize='md'>{chatsId.id}</Text>
-								<Text fontSize='sm' color='gray.400'>{new Date(chatsId.updatedAt.seconds * 1000).toLocaleString()}</Text>
-							</Link>
+						<Box key={chatsId} w='full' px='30px' py='10px' bg='gray.200' borderRadius='10px'>
+							<Editable
+								textAlign='center'
+								defaultValue={chatsId.title ? chatsId.title : chatsId.id}
+								fontSize='md'
+								isPreviewFocusable={false}
+							>
+								<Flex align='center' justify='space-between'>
+									<Link href={`/chat/${chatsId.id}`}>
+										<EditablePreview />
+									</Link>
+									<EditableInput onChange={(e) => setChatTitle(e.target.value)} />
+									<EditableControls userId={currentUser.email} chatsId={chatsId.id} chatTitle={chatTitle} />
+								</Flex>
+							</Editable>
 						</Box>
 					))}
 					<Flex align='center' columnGap='10px' px='30px' py='10px' bg='gray.200' borderRadius='10px'>


### PR DESCRIPTION
<!-- #[Issue num] [prefex]: title -->
<!-- #1 feat: first commit -->
# 目的

- このプルリクエストが解決する課題や目標を記述
- #55 
- #61 

## 背景

- このプルリクエストが必要となった経緯や背景を記述
- 現状チャットタイトルは編集できず、ダッシュボードに表示されるチャットタイトルは、アクセスしたURLに依存している。（例えば/chat/chat1にアクセスしてチャットを行い、ダッシュボートからチャット履歴を閲覧すると、チャットタイトル: chat1となっている。）
- 不要なチャットを削除したいため

## 変更内容

- このプルリクエストで行った変更内容や影響範囲を記述
- チャット一覧に表示するデータの変更
  - 変更前: チャットの`id`と最終更新日時
  - 変更後: チャットタイトルのみを表示。ただしチャットタイトルが未入力時はチャットの`id`を表示
- チャットタイトルを更新する関数の修正
- チャットタイトルを更新するためのテキストフォームとアイコンの追加
- チャットタイトルの削除機能を追加
  - チャットタイトル削除時にダイアログを表示して確認を求めるUIの追加
- チャットデータを取得するコードをコンポーネント内に移動

## テスト方法

- このプルリクエストで行ったテスト方法や結果を記述
- その場その場のデバッグ

## レビューに必要な情報

- レビュアーに伝えたい情報や注意点を記述
- 特になし