### PR TITLE
お知らせページの追加 - Feature/#123 create info page

### DIFF
--- a/src/components/custom-chakra-ui.js
+++ b/src/components/custom-chakra-ui.js
@@ -1,4 +1,4 @@
-import { Box, Button, Checkbox, Flex, Heading, Icon, Text, Textarea, forwardRef } from "@chakra-ui/react";
+import { Box, Button, Checkbox, Flex, Heading, Icon, Text, Textarea, forwardRef, useMediaQuery } from "@chakra-ui/react";
 import { signIn } from "next-auth/react";
 import { useState } from "react";
 import { PiArrowSquareOutFill, PiPaperPlaneTiltFill, PiSignInFill } from "react-icons/pi";
@@ -61,6 +61,24 @@ export const ButtonLink = ({ children, icon = PiArrowSquareOutFill, href = '', i
 			<Flex align='center' columnGap='5px'>
 				<Icon as={icon} fontSize='20px' />
 				<Text fontSize='16px'>{children}</Text>
+			</Flex>
+		</Button>
+	)
+}
+
+export const ResponsiveButtonLink = ({ children, icon = PiArrowSquareOutFill, href = null, isBlank=false, onClick }, props) => {
+	const [mqMd] = useMediaQuery('(min-width: 768px)')
+
+	return (
+		<Button as={href ? 'a' : 'button'} href={href} target={isBlank ? '_blank' : '_self'} rel="noopener noreferrer"
+			onClick={onClick}
+			{...props} variant='unstyled' display='block'
+			h='max' w='max' px={mqMd ? '25px' : '10px'} py='10px' color='black' bg='white'
+			border='2px' borderColor='#884FE4' borderRadius='full' transitionDuration='.3s'
+			_hover={{ color: 'white', bg: '#884FE4' }}>
+			<Flex align='center' columnGap={mqMd ? '5px' : '0'}>
+				<Icon as={icon} fontSize={mqMd ? '20px' : '28px'} />
+				<Text fontSize='16px'>{mqMd ? children : null}</Text>
 			</Flex>
 		</Button>
 	)

--- a/src/components/dashboard-layout.jsx
+++ b/src/components/dashboard-layout.jsx
@@ -1,14 +1,32 @@
 import { DashboardNav } from '@/components/dashboard-nav'
+import { useFirestore } from '@/hooks/useFirestore'
 import { currentUserState } from '@/states/currentUserState'
+import { newsDataState, isNewsUpdatedState } from '@/states/newsDataState'
 import { Box, Flex } from '@chakra-ui/react'
-import { useRecoilValue } from 'recoil'
+import { useEffect, useState } from 'react'
+import { useRecoilState, useRecoilValue } from 'recoil'
 
 export const DashboardLayout = ({ children }) => {
     const currentUser = useRecoilValue(currentUserState)
+    const [newsData, setNewsData] = useRecoilState(newsDataState);
+    const [isNewsUpdated, setIsNewsUpdated] = useRecoilState(isNewsUpdatedState);
+    const [isNewsFetched, setIsNewsFetched] = useState(false);
+    const { getNewsData } = useFirestore();
+
+    useEffect(() => {
+        if (!isNewsFetched) {
+            ; (async () => {
+                const data = await getNewsData();
+                if (data.length !== newsData.length) setIsNewsUpdated(true);
+                setNewsData(data);
+                setIsNewsFetched(true);
+            })()
+        }
+    }, [])
 
     return (
         <Flex h='100dvh' direction={{ base: 'column-reverse', lg: 'row' }} justify='space-between'>
-            <DashboardNav user={currentUser} />
+            <DashboardNav user={currentUser} isNewsUpdated={isNewsUpdated} />
             <Box w='full' p='20px' overflowY='auto'>
                 {children}
             </Box>

--- a/src/components/dashboard-nav.jsx
+++ b/src/components/dashboard-nav.jsx
@@ -29,7 +29,7 @@ export const DashboardNav = ({ user, isNewsUpdated }) => {
 						<Link href='/news'>
 							<Icon boxSize='30px' as={PiBellRingingFill} />
 						</Link>
-						{isNewsUpdated && <Flex position='absolute' top='0' right='0' w='10px' h='10px' bg='cyan.400' borderRadius='50%' />}
+						{isNewsUpdated && <Flex position='absolute' top='-1px' right='4px' w='12px' h='12px' bg='cyan.400' border='2px' borderColor='white' borderRadius='50%' />}
 					</Button>
 					<Button display='block' variant='link' colorScheme='black'>
 						<Link href='/favorites'>

--- a/src/components/dashboard-nav.jsx
+++ b/src/components/dashboard-nav.jsx
@@ -15,7 +15,7 @@ import { signOut } from 'next-auth/react';
 import Link from 'next/link'
 import { PiBellRingingFill, PiDevicesBold, PiGearSixFill, PiHeartFill, PiHouseFill, PiPaperPlaneTiltFill, PiSignOutFill } from 'react-icons/pi';
 
-export const DashboardNav = ({ user }) => {
+export const DashboardNav = ({ user, isNewsUpdated }) => {
 	return (
 		<Flex direction={{ base: 'row', lg: 'column' }} align='center' justify={{ base: 'space-around', lg: 'flex-end' }} h={{ base: '80px', lg: '100dvh' }} w={{ base: '100%', lg: '80px' }} gap={{ base: '20px', lg: '30px' }} px='20px' py='30px' bg='white' border='1px' borderColor='gray.200'>
 			{user ? (
@@ -25,10 +25,11 @@ export const DashboardNav = ({ user }) => {
 							<Icon boxSize='30px' as={PiHouseFill} />
 						</Link>
 					</Button>
-					<Button display='block' variant='link' colorScheme='black'>
+					<Button position='relative' display='block' variant='link' colorScheme='black'>
 						<Link href='/news'>
 							<Icon boxSize='30px' as={PiBellRingingFill} />
 						</Link>
+						{isNewsUpdated && <Flex position='absolute' top='0' right='0' w='10px' h='10px' bg='cyan.400' borderRadius='50%' />}
 					</Button>
 					<Button display='block' variant='link' colorScheme='black'>
 						<Link href='/favorites'>

--- a/src/components/dashboard-nav.jsx
+++ b/src/components/dashboard-nav.jsx
@@ -13,34 +13,36 @@ import {
 } from '@chakra-ui/react'
 import { signOut } from 'next-auth/react';
 import Link from 'next/link'
-import { PiDevicesBold, PiGearSixFill, PiHeartFill, PiHouseFill, PiPaperPlaneTiltFill, PiSignOutFill } from 'react-icons/pi';
+import { PiBellRingingFill, PiDevicesBold, PiGearSixFill, PiHeartFill, PiHouseFill, PiPaperPlaneTiltFill, PiSignOutFill } from 'react-icons/pi';
 
 export const DashboardNav = ({ user }) => {
 	return (
-		<Flex direction={{ base: 'row', lg: 'column' }} align='center' justify={{ base: 'space-around', lg: 'end' }} h={{ base: '80px', lg: '100dvh' }} w={{ base: '100%', lg: '80px' }} gap={{ base: '20px', lg: '30px' }} p={{ base: '0px 30px', sm: '30px 0px' }} bg='greenyellow'>
+		<Flex direction={{ base: 'row', lg: 'column' }} align='center' justify={{ base: 'space-around', lg: 'flex-end' }} h={{ base: '80px', lg: '100dvh' }} w={{ base: '100%', lg: '80px' }} gap={{ base: '20px', lg: '30px' }} px='20px' py='30px' bg='white' border='1px' borderColor='gray.200'>
 			{user ? (
 				<>
-					<Button display='block' variant='link' colorScheme='orange'>
+					<Button display='block' variant='link' colorScheme='black'>
 						<Link href='/dashboard'>
 							<Icon boxSize='30px' as={PiHouseFill} />
-							<Text fontSize='xs'>Home</Text>
 						</Link>
 					</Button>
-					<Button display='block' variant='link' colorScheme='red'>
+					<Button display='block' variant='link' colorScheme='black'>
+						<Link href='/news'>
+							<Icon boxSize='30px' as={PiBellRingingFill} />
+						</Link>
+					</Button>
+					<Button display='block' variant='link' colorScheme='black'>
 						<Link href='/favorites'>
 							<Icon boxSize='30px' as={PiHeartFill} />
-							<Text fontSize='xs'>Favorites</Text>
 						</Link>
 					</Button>
-					<Button display='block' variant='link' colorScheme='cyan'>
+					<Button display='block' variant='link' colorScheme='black'>
 						<a href="https://forms.gle/EWAGxPBGrEeKSWJg9" target="_blank" rel="noopener noreferrer">
 							<Icon boxSize='30px' as={PiPaperPlaneTiltFill} />
-							<Text fontSize='xs'>FeedBack</Text>
 						</a>
 					</Button>
 					<Menu>
 						<MenuButton variant='unstyled' p={0} bg="transparent">
-							<Image src={user.image} alt={user.name} boxSize="50px" borderRadius="50%" />
+							<Image src={user.image} alt={user.name} boxSize="40px" borderRadius="50%" />
 						</MenuButton>
 						<MenuList>
 							<MenuItem>

--- a/src/components/dashboard-nav.jsx
+++ b/src/components/dashboard-nav.jsx
@@ -17,7 +17,7 @@ import { PiBellRingingFill, PiDevicesBold, PiGearSixFill, PiHeartFill, PiHouseFi
 
 export const DashboardNav = ({ user, isNewsUpdated }) => {
 	return (
-		<Flex direction={{ base: 'row', lg: 'column' }} align='center' justify={{ base: 'space-around', lg: 'flex-end' }} h={{ base: '80px', lg: '100dvh' }} w={{ base: '100%', lg: '80px' }} gap={{ base: '20px', lg: '30px' }} px='20px' py='30px' bg='white' border='1px' borderColor='gray.200'>
+		<Flex direction={{ base: 'row', lg: 'column' }} align='center' justify={{ base: 'space-around', lg: 'flex-end' }} h={{ base: '80px', lg: '100dvh' }} w={{ base: '100%', lg: '80px' }} gap={{ base: '20px', lg: '30px' }} px={{ base: '20px', lg: '15px' }} py='30px' bg='white' border='1px' borderColor='gray.200'>
 			{user ? (
 				<>
 					<Button display='block' variant='link' colorScheme='black'>

--- a/src/components/page-header.jsx
+++ b/src/components/page-header.jsx
@@ -1,9 +1,106 @@
-import { Flex, Image } from '@chakra-ui/react'
+import { Flex, Icon, Image, Modal, ModalBody, ModalCloseButton, ModalContent, ModalHeader, ModalOverlay, Text, useDisclosure } from '@chakra-ui/react'
 import React from 'react'
-import { ButtonLink, GradientText } from './custom-chakra-ui'
+import { ButtonLink, GradientText, ResponsiveButtonLink } from './custom-chakra-ui'
 import Link from 'next/link'
+import { PiBellRingingFill, PiClockClockwiseFill, PiEnvelopeSimpleFill } from 'react-icons/pi'
 
-export const PageHeader = () => {
+export const PageHeader = ({ newsData }) => {
+    const { isOpen, onOpen, onClose } = useDisclosure();
+    console.log(newsData)
+
+    const newsDataSample = [
+        {
+            "titleJA": "Bocchi Talkのベータ版がリリースされました！",
+            "contentJA": "こんにちは、Bocchi Talkのベータ版がリリースされました！是非お試しください。",
+            "date": {
+                "seconds": 1631958000,
+                "nanoseconds": 0
+            },
+            "strId": "bocchi-talk-beta-released",
+        },
+        {
+            "titleJA": "Bocchi Talkのベータ版がリリースされました！",
+            "contentJA": "こんにちは、Bocchi Talkのベータ版がリリースされました！是非お試しください。",
+            "date": {
+                "seconds": 1631958000,
+                "nanoseconds": 0
+            },
+            "strId": "bocchi-talk-beta-released",
+        },
+        {
+            "titleJA": "Bocchi Talkのベータ版がリリースされました！",
+            "contentJA": "こんにちは、Bocchi Talkのベータ版がリリースされました！是非お試しください。",
+            "date": {
+                "seconds": 1631958000,
+                "nanoseconds": 0
+            },
+            "strId": "bocchi-talk-beta-released",
+        },
+        {
+            "titleJA": "Bocchi Talkのベータ版がリリースされました！",
+            "contentJA": "こんにちは、Bocchi Talkのベータ版がリリースされました！是非お試しください。",
+            "date": {
+                "seconds": 1631958000,
+                "nanoseconds": 0
+            },
+            "strId": "bocchi-talk-beta-released",
+        },
+        {
+            "titleJA": "Bocchi Talkのベータ版がリリースされました！",
+            "contentJA": "こんにちは、Bocchi Talkのベータ版がリリースされました！是非お試しください。",
+            "date": {
+                "seconds": 1631958000,
+                "nanoseconds": 0
+            },
+            "strId": "bocchi-talk-beta-released",
+        },
+        {
+            "titleJA": "Bocchi Talkのベータ版がリリースされました！",
+            "contentJA": "こんにちは、Bocchi Talkのベータ版がリリースされました！是非お試しください。",
+            "date": {
+                "seconds": 1631958000,
+                "nanoseconds": 0
+            },
+            "strId": "bocchi-talk-beta-released",
+        },
+        {
+            "titleJA": "Bocchi Talkのベータ版がリリースされました！",
+            "contentJA": "こんにちは、Bocchi Talkのベータ版がリリースされました！是非お試しください。",
+            "date": {
+                "seconds": 1631958000,
+                "nanoseconds": 0
+            },
+            "strId": "bocchi-talk-beta-released",
+        },
+        {
+            "titleJA": "Bocchi Talkのベータ版がリリースされました！",
+            "contentJA": "こんにちは、Bocchi Talkのベータ版がリリースされました！是非お試しください。",
+            "date": {
+                "seconds": 1631958000,
+                "nanoseconds": 0
+            },
+            "strId": "bocchi-talk-beta-released",
+        },
+        {
+            "titleJA": "Bocchi Talkのベータ版がリリースされました！",
+            "contentJA": "こんにちは、Bocchi Talkのベータ版がリリースされました！是非お試しください。",
+            "date": {
+                "seconds": 1631958000,
+                "nanoseconds": 0
+            },
+            "strId": "bocchi-talk-beta-released",
+        },
+        {
+            "titleJA": "Bocchi Talkのベータ版がリリースされました！",
+            "contentJA": "こんにちは、Bocchi Talkのベータ版がリリースされました！是非お試しください。",
+            "date": {
+                "seconds": 1631958000,
+                "nanoseconds": 0
+            },
+            "strId": "bocchi-talk-beta-released",
+        },
+    ]
+
     return (
         <Flex align='center' justify='space-between' h='70px' w='100%' >
             <Link href='/'>
@@ -12,7 +109,41 @@ export const PageHeader = () => {
                     <GradientText fontSize='24px' fontWeight='bold'>Bocchi Talk</GradientText>
                 </Flex>
             </Link>
-            <ButtonLink href='https://forms.gle/NK5GJSAVJzUGDtao7' isBlank={true}>お問い合わせ</ButtonLink>
+            <Flex align='center' justify='center' gap='10px'>
+                <ResponsiveButtonLink icon={PiBellRingingFill} onClick={onOpen}>お知らせ</ResponsiveButtonLink>
+                <ResponsiveButtonLink icon={PiEnvelopeSimpleFill} href='https://forms.gle/NK5GJSAVJzUGDtao7' isBlank={true}>お問い合わせ</ResponsiveButtonLink>
+            </Flex>
+
+            <Modal
+                isOpen={isOpen}
+                onClose={onClose}
+                isCentered
+                motionPreset='slideInBottom'
+            >
+                <ModalOverlay />
+                <ModalContent maxW='80vw'>
+                    <ModalHeader>お知らせ</ModalHeader>
+                    <ModalCloseButton />
+                    <ModalBody h='auto' maxH='70vh' overflowY='scroll'>
+                        {newsDataSample.slice()
+                            .sort((b, a) => a.date.seconds - b.date.seconds)
+                            .map((news) => (
+                                <Flex direction='column' align='flex-start' key={news.strId} mb='30px'>
+                                    <Flex justify='flex-start' columnGap='10px' w='100%' mb='10px'>
+                                        <Flex align='center' columnGap='5px'>
+                                            <Icon as={PiClockClockwiseFill} fontSize='16px' />
+                                            <Text fontSize='14px'>
+                                                {new Date(news.date.seconds * 1000).toLocaleDateString('ja-JP')}
+                                            </Text>
+                                        </Flex>
+                                        <Text fontSize='20px' fontWeight='bold'>{news.titleJA}</Text>
+                                    </Flex>
+                                    <Text fontSize='16px'>{news.contentJA}</Text>
+                                </Flex>
+                            ))}
+                    </ModalBody>
+                </ModalContent>
+            </Modal>
         </Flex>
     )
 }

--- a/src/components/page-header.jsx
+++ b/src/components/page-header.jsx
@@ -1,105 +1,11 @@
-import { Flex, Icon, Image, Modal, ModalBody, ModalCloseButton, ModalContent, ModalHeader, ModalOverlay, Text, useDisclosure } from '@chakra-ui/react'
+import { Box, Flex, Icon, Image, Modal, ModalBody, ModalCloseButton, ModalContent, ModalHeader, ModalOverlay, Text, useDisclosure } from '@chakra-ui/react'
 import React from 'react'
 import { ButtonLink, GradientText, ResponsiveButtonLink } from './custom-chakra-ui'
 import Link from 'next/link'
-import { PiBellRingingFill, PiClockClockwiseFill, PiEnvelopeSimpleFill } from 'react-icons/pi'
+import { PiArrowSquareOutFill, PiBellRingingFill, PiClockClockwiseFill, PiEnvelopeSimpleFill } from 'react-icons/pi'
 
 export const PageHeader = ({ newsData }) => {
     const { isOpen, onOpen, onClose } = useDisclosure();
-    console.log(newsData)
-
-    const newsDataSample = [
-        {
-            "titleJA": "Bocchi Talkのベータ版がリリースされました！",
-            "contentJA": "こんにちは、Bocchi Talkのベータ版がリリースされました！是非お試しください。",
-            "date": {
-                "seconds": 1631958000,
-                "nanoseconds": 0
-            },
-            "strId": "bocchi-talk-beta-released",
-        },
-        {
-            "titleJA": "Bocchi Talkのベータ版がリリースされました！",
-            "contentJA": "こんにちは、Bocchi Talkのベータ版がリリースされました！是非お試しください。",
-            "date": {
-                "seconds": 1631958000,
-                "nanoseconds": 0
-            },
-            "strId": "bocchi-talk-beta-released",
-        },
-        {
-            "titleJA": "Bocchi Talkのベータ版がリリースされました！",
-            "contentJA": "こんにちは、Bocchi Talkのベータ版がリリースされました！是非お試しください。",
-            "date": {
-                "seconds": 1631958000,
-                "nanoseconds": 0
-            },
-            "strId": "bocchi-talk-beta-released",
-        },
-        {
-            "titleJA": "Bocchi Talkのベータ版がリリースされました！",
-            "contentJA": "こんにちは、Bocchi Talkのベータ版がリリースされました！是非お試しください。",
-            "date": {
-                "seconds": 1631958000,
-                "nanoseconds": 0
-            },
-            "strId": "bocchi-talk-beta-released",
-        },
-        {
-            "titleJA": "Bocchi Talkのベータ版がリリースされました！",
-            "contentJA": "こんにちは、Bocchi Talkのベータ版がリリースされました！是非お試しください。",
-            "date": {
-                "seconds": 1631958000,
-                "nanoseconds": 0
-            },
-            "strId": "bocchi-talk-beta-released",
-        },
-        {
-            "titleJA": "Bocchi Talkのベータ版がリリースされました！",
-            "contentJA": "こんにちは、Bocchi Talkのベータ版がリリースされました！是非お試しください。",
-            "date": {
-                "seconds": 1631958000,
-                "nanoseconds": 0
-            },
-            "strId": "bocchi-talk-beta-released",
-        },
-        {
-            "titleJA": "Bocchi Talkのベータ版がリリースされました！",
-            "contentJA": "こんにちは、Bocchi Talkのベータ版がリリースされました！是非お試しください。",
-            "date": {
-                "seconds": 1631958000,
-                "nanoseconds": 0
-            },
-            "strId": "bocchi-talk-beta-released",
-        },
-        {
-            "titleJA": "Bocchi Talkのベータ版がリリースされました！",
-            "contentJA": "こんにちは、Bocchi Talkのベータ版がリリースされました！是非お試しください。",
-            "date": {
-                "seconds": 1631958000,
-                "nanoseconds": 0
-            },
-            "strId": "bocchi-talk-beta-released",
-        },
-        {
-            "titleJA": "Bocchi Talkのベータ版がリリースされました！",
-            "contentJA": "こんにちは、Bocchi Talkのベータ版がリリースされました！是非お試しください。",
-            "date": {
-                "seconds": 1631958000,
-                "nanoseconds": 0
-            },
-            "strId": "bocchi-talk-beta-released",
-        },
-        {
-            "titleJA": "Bocchi Talkのベータ版がリリースされました！",
-            "contentJA": "こんにちは、Bocchi Talkのベータ版がリリースされました！是非お試しください。",
-            "date": {
-                "seconds": 1631958000,
-                "nanoseconds": 0
-            },
-            "strId": "bocchi-talk-beta-released",
-        },
-    ]
 
     return (
         <Flex align='center' justify='space-between' h='70px' w='100%' >
@@ -124,20 +30,30 @@ export const PageHeader = ({ newsData }) => {
                 <ModalContent maxW='80vw'>
                     <ModalHeader>お知らせ</ModalHeader>
                     <ModalCloseButton />
-                    <ModalBody h='auto' maxH='70vh' overflowY='scroll'>
-                        {newsDataSample.slice()
+                    <ModalBody h='auto' maxH='70vh' overflowY='auto'>
+                        {newsData.slice()
                             .sort((b, a) => a.date.seconds - b.date.seconds)
                             .map((news) => (
                                 <Flex direction='column' align='flex-start' key={news.strId} mb='30px'>
-                                    <Flex justify='flex-start' columnGap='10px' w='100%' mb='10px'>
+                                    <Flex direction={{ base: 'column', md: 'row' }} justify='flex-start' gap={{ base: '5px', md: '10px' }} w='100%' mb='10px'>
                                         <Flex align='center' columnGap='5px'>
                                             <Icon as={PiClockClockwiseFill} fontSize='16px' />
                                             <Text fontSize='14px'>
                                                 {new Date(news.date.seconds * 1000).toLocaleDateString('ja-JP')}
                                             </Text>
                                         </Flex>
-                                        <Text fontSize='20px' fontWeight='bold'>{news.titleJA}</Text>
+                                        <Link
+                                            href={(news.linkURL === '#') ? '' : news.linkURL}
+                                            target={news.isInNewTab ? '_blank' : '_self'}
+                                            rel="noopener noreferrer"
+                                        >
+                                            <Text color={(news.linkURL === '#') ? 'black' : '#884FE4'} fontSize='20px' fontWeight='bold'>
+                                                {news.isInNewTab && <Icon as={PiArrowSquareOutFill} mr='2px' fontSize='24px' color='#884FE4' verticalAlign='text-bottom' />}
+                                                {news.titleJA}
+                                            </Text>
+                                        </Link>
                                     </Flex>
+
                                     <Text fontSize='16px'>{news.contentJA}</Text>
                                 </Flex>
                             ))}

--- a/src/pages/dashboard/index.jsx
+++ b/src/pages/dashboard/index.jsx
@@ -17,12 +17,9 @@ import { useFirestore } from '@/hooks/useFirestore'
 export default function Dashboard() {
 	const [chatsData, setChatsData] = useRecoilState(chatsDataState)
 	const { isLoading, isPageLoading } = useLoading()
-	const { getNewsData } = useFirestore()
 	const hoveredChat = useRecoilValue(hoveredChatState)
 	const currentUser = useRecoilValue(currentUserState)
 	const [currentChatTitle, setCurrentChatTitle] = useState('')
-	const [ newsData, setNewsData ] = useState([])
-	const [ isFetched, setIsFetched ] = useState(false);
 
 	if (currentUser && chatsData.length === 0) {
 		; (async () => {
@@ -39,14 +36,6 @@ export default function Dashboard() {
 	}
 
 	const randomSlug = Randomstring.generate(16);
-	
-	if (currentUser && !isFetched) {
-		; (async () => {
-			const data = await getNewsData();
-			setNewsData(data);
-			setIsFetched(true);
-		})()
-	}
 
 	return (
 		<DashboardLayout>
@@ -79,33 +68,6 @@ export default function Dashboard() {
 					<Link href={`/chat/${randomSlug}`}>新しくチャットを始める</Link>
 				</Flex>
 			</Flex>
-			<Heading as='h1' size='lg' mt='10px'>News</Heading>
-			<Accordion allowToggle py='20px'>
-				{newsData.slice() // オリジナルの配列を変更せずにコピーを作成
-  				.sort((b, a) => a.date.seconds - b.date.seconds) // 日付でソート
-  				.map((newData, index) => (
-					<AccordionItem key={index}>
-						<h2>
-							<AccordionButton>
-								<Flex as="span" textAlign='left'>
-									<Icon as={PiBellZBold} w={6} h={6} mr={2} color='slategray' />
-									<Text fontSize='md'>{newData.titleJA}</Text>
-								</Flex>
-								<Spacer />
-								<Text pr={2} color='gray.500'>-{new Date(newData.date.seconds * 1000).toLocaleDateString('ja-JP')}-</Text>
-								<AccordionIcon />
-							</AccordionButton>
-						</h2>
-						<AccordionPanel pb={4} pl={12}>
-							{newData.isInNewTab?(
-								<Link href={newData.linkURL} target="_blank" rel="noopener noreferrer"><Text fontSize='sm'>{newData.contentJA}</Text></Link>
-							) : (
-								<Link href={newData.linkURL}><Text fontSize='sm'>{newData.contentJA}</Text></Link>
-							)}
-						</AccordionPanel>
-					</AccordionItem>
-				))}
-			</Accordion>
 		</DashboardLayout>
 	)
 }

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -4,9 +4,25 @@ import { Box, Flex, Heading, Image, Text } from '@chakra-ui/react'
 import { ButtonLink, GradientHeading, LoginButton, PrimaryButton, Text100, Text110, Title100 } from '@/components/custom-chakra-ui'
 import { authOptions } from '@/pages/api/auth/[...nextauth]'
 import { getServerSession } from 'next-auth'
+import { useFirestore } from '@/hooks/useFirestore'
+import { useState } from 'react'
 
 
 export default function Home() {
+  const [newsData, setNewsData] = useState([]);
+  const [isNewsFetched, setIsNewsFetched] = useState(false);
+  const { getNewsData } = useFirestore();
+
+  if (!isNewsFetched) {
+    ; (async () => {
+      const data = await getNewsData();
+      setNewsData(data);
+      setIsNewsFetched(true);
+    })()
+  }
+
+  // TODO 取得したデータをUIで表示する
+
   const reasons = [
     {
       "key": 1,
@@ -40,7 +56,7 @@ export default function Home() {
       </Head>
       <main>
         <Box id='headerSection' h={{ base: 'full', lg: '700px' }} maxW='1080px' px={{ base: '20px', lg: '0' }} mx='auto' overflowY='hidden'>
-          <PageHeader />
+          <PageHeader newsData={newsData} />
           <Flex direction={{ base: 'column-reverse', lg: 'row' }} align={{ base: 'center', lg: 'flex-start' }} justify='center' gap='50px'
             maxW='inherit' pt={{ base: '30px', lg: '80px' }} pb={{ base: '50px', lg: '0' }} mx='auto'>
             <Image w={{ base: '300px', md: '350px' }} src='/hero-mobile.png' alt='hero image' />

--- a/src/pages/news/index.jsx
+++ b/src/pages/news/index.jsx
@@ -1,27 +1,24 @@
 import { DashboardLayout } from "@/components/dashboard-layout";
-import { useFirestore } from "@/hooks/useFirestore";
+import { newsDataState, isNewsUpdatedState } from "@/states/newsDataState";
 import { Box, Flex, Heading, Icon, Text } from "@chakra-ui/react";
 import Link from "next/link";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { PiArrowSquareOutFill, PiClockClockwiseFill } from "react-icons/pi";
+import { useRecoilValue, useSetRecoilState } from "recoil";
 
 export default function notification() {
-    const [newsData, setNewsData] = useState([]);
+    const newsData = useRecoilValue(newsDataState);
+    const setIsNewsUpdated = useSetRecoilState(isNewsUpdatedState)
     const [isNewsFetched, setIsNewsFetched] = useState(false);
-    const { getNewsData } = useFirestore();
-
-    if (!isNewsFetched) {
-        ; (async () => {
-            const data = await getNewsData();
-            setNewsData(data);
-            setIsNewsFetched(true);
-        })()
-    }
+    useEffect(() => {
+        if (!isNewsFetched) setIsNewsFetched(true);
+        setIsNewsUpdated(false);
+    }, [])
 
     return (
         <DashboardLayout>
             <Heading as='h1' size='lg' mb='20px'>News</Heading>
-            {newsData.slice()
+            {isNewsFetched && newsData.slice()
                 .sort((b, a) => a.date.seconds - b.date.seconds)
                 .map((news) => (
                     <Flex direction='column' align='flex-start' key={news.strId} mb='20px' p='20px' bg='gray.100' borderRadius='10px'>

--- a/src/pages/news/index.jsx
+++ b/src/pages/news/index.jsx
@@ -1,0 +1,53 @@
+import { DashboardLayout } from "@/components/dashboard-layout";
+import { useFirestore } from "@/hooks/useFirestore";
+import { Box, Flex, Heading, Icon, Text } from "@chakra-ui/react";
+import Link from "next/link";
+import { useState } from "react";
+import { PiArrowSquareOutFill, PiClockClockwiseFill } from "react-icons/pi";
+
+export default function notification() {
+    const [newsData, setNewsData] = useState([]);
+    const [isNewsFetched, setIsNewsFetched] = useState(false);
+    const { getNewsData } = useFirestore();
+
+    if (!isNewsFetched) {
+        ; (async () => {
+            const data = await getNewsData();
+            setNewsData(data);
+            setIsNewsFetched(true);
+        })()
+    }
+
+    return (
+        <DashboardLayout>
+            <Heading as='h1' size='lg' mb='20px'>News</Heading>
+            {newsData.slice()
+                .sort((b, a) => a.date.seconds - b.date.seconds)
+                .map((news) => (
+                    <Flex direction='column' align='flex-start' key={news.strId} mb='20px' p='20px' bg='gray.100' borderRadius='10px'>
+                        <Flex direction={{ base: 'column', md: 'row' }} justify='flex-start' gap={{ base: '5px', md: '10px' }} w='100%' mb='10px'>
+                            <Flex align='center' columnGap='5px'>
+                                <Icon as={PiClockClockwiseFill} fontSize='16px' />
+                                <Text fontSize='14px'>
+                                    {new Date(news.date.seconds * 1000).toLocaleDateString('ja-JP')}
+                                </Text>
+                            </Flex>
+                            <Link
+                                href={(news.linkURL === '#') ? '' : news.linkURL}
+                                target={news.isInNewTab ? '_blank' : '_self'}
+                                rel="noopener noreferrer"
+                            >
+                                <Text color={(news.linkURL === '#') ? 'black' : '#884FE4'} fontSize='20px' fontWeight='bold'>
+                                    {news.isInNewTab && <Icon as={PiArrowSquareOutFill} mr='2px' fontSize='24px' color='#884FE4' verticalAlign='text-bottom' />}
+                                    {news.titleJA}
+                                </Text>
+                            </Link>
+                        </Flex>
+
+                        <Text fontSize='16px'>{news.contentJA}</Text>
+                    </Flex>
+                ))
+            }
+        </DashboardLayout>
+    )
+}

--- a/src/states/newsDataState.js
+++ b/src/states/newsDataState.js
@@ -1,0 +1,31 @@
+const { atom } = require("recoil");
+
+const localStorageEffect = key => ({ setSelf, onSet }) => {
+    if (typeof window === 'undefined') return;
+    const savedValue = localStorage.getItem(key);
+    if (savedValue !== null) {
+        setSelf(JSON.parse(savedValue));
+    }
+
+    onSet(newValue => {
+        localStorage.setItem(key, JSON.stringify(newValue));
+    });
+};
+
+const newsDataState = atom({
+    key: 'newsData',
+    default: [],
+    effects: [
+        localStorageEffect('newsData'),
+    ]
+});
+
+const isNewsUpdatedState = atom({
+    key: 'isNewsUpdated',
+    default: false,
+    effects: [
+        localStorageEffect('isNewsUpdated'),
+    ]
+});
+
+export { newsDataState, isNewsUpdatedState };


### PR DESCRIPTION
<!-- ⚠️#[Issue num] [prefex]: title -->
<!-- #1 feat: first commit -->

<!-- なお記入しない項目は削除せず、そのまま放置すること -->
## レビュー優先度

- [ ] 🚀 今すぐ確認してほしい
- [ ] 🚗 今日中に確認してほしい
- [ ] 🏃 3日以内に確認してほしい
- [ ] 🐢 5日以内までに確認してほしい

## レビュー深さ

- [ ] 🕵️ 該当Issueから考慮してレビューしてほしい
- [ ] 🧪 ローカルで動作確認してほしい
- [ ] 🔍 コードロジックを理解して確認してほしい
- [ ] 👀 ぱっと確認するだけで良い

## 関連Issue
<!-- e.g.
- #10
- #20
- #30
 -->

- #123 

## 概要（ざっくり）
<!-- このプルリクエストが解決する課題や目標を記述 -->
- お知らせページを実装
  - トップページ
  - ダッシュボード
  - 両方とも
- ダッシュボードトップのお知らせセクションを削除
- ナビゲーションバーのデザインを新調
- 新規お知らせがあるときにアイコンのアクセントを追加

## ユーザー側の変更内容
<!-- このプルリクエストで追加・削除した機能・ユーザーへの報告事項について記述 -->
- お知らせページが出来ました
  - トップページからも確認できます
  - ダッシュボードにてお知らせページを新たに作成しました
- 新規お知らせがあるときにお知らせアイコンに水色のアクセントが追加されるようになりました
- その他アプリのデザインを調整しました

## コードの変更内容
<!-- このプルリクエストで行った変更内容や影響範囲を記述 -->
- `dashboard-Layout.jsx`にてお知らせを取得することにした
- 以下の2つを新たにlocalStorageで管理する
  - お知らせ情報
  - 新規お知らせが来たかどうか
- 

## スクリーンショット（可能であれば）

### トップページのお知らせ

![image](https://github.com/hengin-eer/bocchi-talk/assets/102217304/115d86a9-6f69-4ed8-b0fe-ac5dae2fc641)


### ダッシュボードのお知らせ

![image](https://github.com/hengin-eer/bocchi-talk/assets/102217304/1dd85750-53a4-4c76-850c-9f1c42419ae0)


### 新規お知らせのデモ

![20231017094351](https://github.com/hengin-eer/bocchi-talk/assets/102217304/7f922520-0a35-4cbb-9144-6f7345acb9f7)


## レビューに必要な情報
<!-- レビュアーに伝えたい情報や注意点を記述 -->
- .
